### PR TITLE
Document ULC 1.9 configuration additions

### DIFF
--- a/pages/ulc/configuration.mdx
+++ b/pages/ulc/configuration.mdx
@@ -75,6 +75,13 @@ features.
       -- delay between checks, this can be very long, it will only make it more realistic
       delay = 10,
   },
+
+  -- Global horn timing defaults, in milliseconds.
+  -- Vehicles can override either value in their hornConfig.
+  HornSettings = {
+      hornPressDelay = 0,
+      hornReleaseDelay = 0,
+  },
   ...
 ```
 

--- a/pages/ulc/configuration/buttons.md
+++ b/pages/ulc/configuration/buttons.md
@@ -80,6 +80,31 @@ The extra field specifies the primary extra for the button. This extra will alwa
 extra = 8,
 ```
 
+#### requiredExtras
+
+`requiredExtras` is an optional table of extras that must all be enabled before
+the button appears in the ULC HUD and its numpad keybind is available. Use it
+to hide controls that only apply to a vehicle variant, such as a lightbar button
+on a slick-top vehicle.
+
+It is also useful when extras change a lightbar pattern but the lightbar itself
+is an extra. If the lightbar is disabled, the buttons that control its patterns
+will be hidden.
+
+```lua
+-- This button controls extra 8, but is only available while extra 10 is enabled.
+extra = 8,
+requiredExtras = {10},
+```
+
+ULC checks these requirements when the vehicle is entered and again within one
+second after an external resource changes a listed extra. When a requirement is
+not met, the button is hidden rather than disabled.
+
+To prevent flashing and other issues, required extras must not be controlled by
+ULC. For example, if extra 1 is your Stage 1 lights, it cannot be the required
+extra for Stage 2.
+
 #### linkedExtras
 
 Linked extras specifies extras that will match the state of the main extra when the key is pressed. Consider the example below:

--- a/pages/ulc/configuration/horn-extras.md
+++ b/pages/ulc/configuration/horn-extras.md
@@ -1,8 +1,25 @@
 # Horn Extras
 
-This feature allows you to bind extras to your airhorn. For example, you could enable a more aggressive/faster pattern , or takedown lights while the horn is in use.
+This feature allows you to bind extras to your airhorn. For example, you could enable a more aggressive or faster pattern, or takedown lights while the horn is in use.
 
 Simply create a stage extra as usual, and assign it in the config.
+
+Horn extras can activate immediately or after the horn has been held for a
+configured amount of time. They can also remain active briefly after the horn
+is released. Both delays are measured in milliseconds and apply to
+`hornExtras` and `disableExtras`.
+
+## Global Horn Timing Config
+
+Set server-wide defaults in the ULC resource's `config.lua` file. A value of
+`0` keeps the original instant behavior.
+
+```lua
+HornSettings = {
+    hornPressDelay = 0,
+    hornReleaseDelay = 0,
+},
+```
 
 ## Vehicle Horn Extras Config
 
@@ -10,6 +27,21 @@ Simply create a stage extra as usual, and assign it in the config.
 hornConfig = {
     useHorn = true,
     hornExtras = {12},
-    disableExtras = {11}
+    disableExtras = {11},
+    -- Optional: nil inherits the matching Config.HornSettings value.
+    hornPressDelay = nil,
+    hornReleaseDelay = nil,
 },
 ```
+
+- `hornPressDelay` controls how long the horn must be held before the configured
+  extras activate. Releasing the horn before this delay expires prevents them
+  from activating.
+- `hornReleaseDelay` controls how long the configured extras remain active
+  after the horn is released. Pressing the horn again during this delay cancels
+  the pending restoration, so the extras remain active.
+
+Each delay is resolved independently. A value set in the vehicle's `hornConfig`
+takes priority, followed by the matching global `Config.HornSettings` value,
+then `0`. Use `0` to explicitly select instant behavior. Use `nil`, or omit the
+field, to inherit the global value.

--- a/pages/ulc/integrations/_meta.json
+++ b/pages/ulc/integrations/_meta.json
@@ -1,4 +1,5 @@
 {
+  "events": "Events",
   "real-brake-lights": "Real Brake Lights",
   "lvc": "Luxart Vehicle Control"
 }

--- a/pages/ulc/integrations/events.mdx
+++ b/pages/ulc/integrations/events.mdx
@@ -1,0 +1,132 @@
+---
+title: ULC Events
+description: Use ULC events from other FiveM resources.
+---
+
+# ULC Events
+
+ULC provides client events that other FiveM resources can use to control
+configured vehicle extras or react to lighting state changes.
+
+These events are client-side. Call them with `TriggerEvent` and listen for them
+with `AddEventHandler`. Do not use `TriggerServerEvent` for the events on this
+page.
+
+## Set an extra or stage
+
+Use `ulc:SetStage` to enable, disable, or toggle an extra on the vehicle that
+the local player is currently using with ULC.
+
+```lua
+TriggerEvent(
+    "ulc:SetStage",
+    extra,
+    action,
+    playSound,
+    extraOnly,
+    repair,
+    forceChange,
+    forceUi
+)
+```
+
+### Arguments
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `extra` | number | The vehicle extra ID to control. |
+| `action` | number | `0` enables, `1` disables, and `2` toggles the extra. |
+| `playSound` | boolean | Plays ULC's enable or disable beep when the extra belongs to a configured button. |
+| `extraOnly` | boolean | When `true`, changes only this extra. When `false`, ULC also processes its configured linked, opposite, and off extras. |
+| `repair` | boolean | Uses ULC's repair behavior while changing the extra. The change is rejected if the vehicle is damaged or a door is open. Usually `false`. |
+| `forceChange` | boolean | Processes the action even if the extra is already in the requested state. This is useful when linked or off extras must still be processed. Usually `false`. |
+| `forceUi` | boolean | Forces the configured ULC button display to update when `extraOnly` is `true`. Usually `false`. |
+
+The player must be inside a vehicle recognized by ULC. If `extra` belongs to a
+configured ULC button, using `extraOnly = false` preserves that button's normal
+stage and linked-extra behavior.
+
+### Examples
+
+Enable extra 12 and process its configured linked, opposite, and off extras:
+
+```lua
+TriggerEvent("ulc:SetStage", 12, 0, true, false, false, false, false)
+```
+
+Disable only extra 12 without playing a sound:
+
+```lua
+TriggerEvent("ulc:SetStage", 12, 1, false, true, false, false, false)
+```
+
+Toggle extra 12 and update its ULC button:
+
+```lua
+TriggerEvent("ulc:SetStage", 12, 2, true, false, false, false, true)
+```
+
+## Listen for ULC state changes
+
+External client resources can listen for the following events. These events
+are notifications from ULC; use them to react to state changes rather than to
+control those states.
+
+### Emergency lights
+
+`ulc:lightsOn` is emitted when the local vehicle's emergency lights turn on.
+`ulc:lightsOff` is emitted when they turn off. Neither event has arguments.
+
+```lua
+AddEventHandler("ulc:lightsOn", function()
+    print("Emergency lights turned on")
+end)
+
+AddEventHandler("ulc:lightsOff", function()
+    print("Emergency lights turned off")
+end)
+```
+
+### Park and drive states
+
+`ulc:vehPark` is emitted when ULC changes to its parked-lighting state.
+`ulc:vehDrive` is emitted when ULC changes back to its driving-lighting state.
+Neither event has arguments.
+
+```lua
+AddEventHandler("ulc:vehPark", function()
+    print("ULC entered the parked state")
+end)
+
+AddEventHandler("ulc:vehDrive", function()
+    print("ULC entered the driving state")
+end)
+```
+
+### Turn indicators
+
+`ulc:indicatorStateChanged` is emitted when the local vehicle's turn-indicator
+state changes.
+
+```lua
+AddEventHandler("ulc:indicatorStateChanged", function(newState, oldState)
+    print(("Indicator state changed from %s to %s"):format(oldState, newState))
+end)
+```
+
+| Argument | Type | Description |
+| --- | --- | --- |
+| `newState` | number | The current indicator state: `0` off, `1` left, `2` right, or `3` hazards. |
+| `oldState` | number | The indicator state before the change, using the same values. |
+
+The state-change events describe the local player's current vehicle. If an
+integration needs a vehicle handle, it can retrieve it when the event runs:
+
+```lua
+AddEventHandler("ulc:lightsOn", function()
+    local vehicle = GetVehiclePedIsIn(PlayerPedId(), false)
+    if vehicle == 0 then return end
+
+    -- Use the vehicle in your integration.
+end)
+```


### PR DESCRIPTION
## Summary

Documents the ULC 1.9 configuration additions:

- conditional buttons using `requiredExtras`
- global and per-vehicle horn press/release timing
- `ulc:SetStage` integration event reference

## Impact

Vehicle developers can configure the new release features with examples and field-level behavior notes.

## Validation

Reviewed the documentation changes against the `ulc-version-1.9` branch.